### PR TITLE
chore(test): configure swagger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.0</version>
+        <version>3.3.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.example</groupId>
@@ -87,6 +87,11 @@
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
             <version>4.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/example/skilllinkbackend/config/security/SecurityConfigurations.java
+++ b/src/main/java/com/example/skilllinkbackend/config/security/SecurityConfigurations.java
@@ -37,6 +37,12 @@ public class SecurityConfigurations {
                 .authorizeHttpRequests(req -> req
                         .requestMatchers(HttpMethod.POST, "/login").permitAll()
                         .requestMatchers(HttpMethod.POST, "/users/register").permitAll()
+                        .requestMatchers(
+                                "/swagger-ui/",
+                                "/swagger-ui/**",
+                                "/swagger-ui/index.html",
+                                "/v3/api-docs",
+                                "/v3/api-docs/swagger-config").permitAll()
                         .anyRequest()
                         .authenticated()
                 )

--- a/src/main/java/com/example/skilllinkbackend/config/springdoc/SpringDocConfiguration.java
+++ b/src/main/java/com/example/skilllinkbackend/config/springdoc/SpringDocConfiguration.java
@@ -1,0 +1,32 @@
+package com.example.skilllinkbackend.config.springdoc;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringDocConfiguration {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearer-key",
+                                new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")))
+                .info(new Info()
+                        .title("Skill Link API")
+                        .description("API Rest de la aplicación Skill Link que contiene las funcionalidades CRUD de categorías, proyectos, desafíos, evaluaciones, además gestiona la autenticación de usuarios")
+                        .contact(new Contact()
+                                .name("Equipo Backend")
+                                .email("luiggiyantas@gmail.com")
+                        )
+                        .license(new License()
+                                .name("Licencia MIT")
+                                .url("http://skilllink/api/licencia"))
+                );
+    }
+}

--- a/src/main/java/com/example/skilllinkbackend/features/auth/controller/AuthenticationController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/auth/controller/AuthenticationController.java
@@ -5,6 +5,11 @@ import com.example.skilllinkbackend.features.auth.model.DataJWTToken;
 import com.example.skilllinkbackend.features.auth.service.TokenService;
 import com.example.skilllinkbackend.features.auth.validation.password.IPasswordValidationService;
 import com.example.skilllinkbackend.features.usuario.model.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -17,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/login")
+@Tag(name = "Autenticación", description = "Inicio de sesión de usuarios y generación de token JWT")
 public class AuthenticationController {
 
     private final AuthenticationManager authenticationManager;
@@ -31,6 +37,19 @@ public class AuthenticationController {
         this.passwordValidationService = passwordValidationService;
     }
 
+    @Operation(
+            summary = "Autenticar usuario",
+            description = "Permite a un usuario iniciar sesión y obtener un token JWT para futuras peticiones protegidas",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Credenciales del usuario",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = UserAuthenticationDataDTO.class))
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Autenticación exitosa, se devuelve el token JWT"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos o contraseña no válida", content = @Content)
+            }
+    )
     @PostMapping
     public ResponseEntity authenticateUser(@RequestBody @Valid UserAuthenticationDataDTO userAuthenticationDataDTO){
         passwordValidationService.validatePassword(new String(userAuthenticationDataDTO.password()));

--- a/src/main/java/com/example/skilllinkbackend/features/auth/dto/UserAuthenticationDataDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/auth/dto/UserAuthenticationDataDTO.java
@@ -1,10 +1,15 @@
 package com.example.skilllinkbackend.features.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "Datos necesarios para iniciar sesión")
 public record UserAuthenticationDataDTO(
+        @Schema(description = "Correo del usuario", example = "alexey@gmail.com")
         @NotBlank
         String email,
+
+        @Schema(description = "Contraseña del usuario", example = "12345678A")
         @NotBlank
         String password
 ) {

--- a/src/main/java/com/example/skilllinkbackend/features/category/controller/CategoryController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/category/controller/CategoryController.java
@@ -4,6 +4,12 @@ import com.example.skilllinkbackend.features.category.dto.CategoryRegisterDTO;
 import com.example.skilllinkbackend.features.category.dto.CategoryResponseDTO;
 import com.example.skilllinkbackend.features.category.dto.CategoryUpdateDTO;
 import com.example.skilllinkbackend.features.category.service.ICategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
@@ -19,6 +25,8 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/categories")
+@SecurityRequirement(name = "bearer-key")
+@Tag(name = "Categorías", description = "Operaciones relacionadas con la gestión de categorías")
 public class CategoryController {
 
     private final ICategoryService categoryService;
@@ -27,6 +35,13 @@ public class CategoryController {
         this.categoryService = categoryService;
     }
 
+    @Operation(
+            summary = "Crear una nueva categoría",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Categoría creada exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content)
+            }
+    )
     @PostMapping
     @Transactional
     public ResponseEntity<CategoryResponseDTO> createCategory(
@@ -38,6 +53,17 @@ public class CategoryController {
         return ResponseEntity.created(url).body(categoryResponseDTO);
     }
 
+    @Operation(
+            summary = "Listar categorías con paginación",
+            parameters = {
+                    @Parameter(name = "page", description = "Número de página (0-indexado)", example = "0"),
+                    @Parameter(name = "size", description = "Cantidad de elementos por página", example = "10"),
+                    @Parameter(name = "sort", description = "Campo para ordenar (ej: id,asc)", example = "id,asc")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Lista de categorías")
+            }
+    )
     @GetMapping
     public Map<String, Object> getCategories(@PageableDefault(size = 10, sort = "id") Pageable pagination) {
         Page<CategoryResponseDTO> categoryPage = categoryService.getCategories(pagination);
@@ -52,11 +78,26 @@ public class CategoryController {
         return response;
     }
 
+    @Operation(
+            summary = "Obtener una categoría por su ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Categoría encontrada"),
+                    @ApiResponse(responseCode = "404", description = "Categoría no encontrada", content = @Content)
+            }
+    )
     @GetMapping("/{id}")
     public CategoryResponseDTO findById(@PathVariable Long id) {
         return categoryService.findById(id);
     }
 
+    @Operation(
+            summary = "Actualizar una categoría existente",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Categoría actualizada exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "Categoría no encontrada", content = @Content)
+            }
+    )
     @PutMapping("/{id}")
     @Transactional
     public CategoryResponseDTO updateCategory(
@@ -65,6 +106,13 @@ public class CategoryController {
         return categoryService.updateCategory(id, categoryUpdateDTO);
     }
 
+    @Operation(
+            summary = "Eliminar una categoría por ID",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Categoría eliminada exitosamente"),
+                    @ApiResponse(responseCode = "404", description = "Categoría no encontrada", content = @Content)
+            }
+    )
     @DeleteMapping("/{id}")
     @Transactional
     public ResponseEntity<Void> deleteCategory(@PathVariable Long id) {

--- a/src/main/java/com/example/skilllinkbackend/features/category/dto/CategoryRegisterDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/category/dto/CategoryRegisterDTO.java
@@ -1,8 +1,11 @@
 package com.example.skilllinkbackend.features.category.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "Datos para registrar una categoría")
 public record CategoryRegisterDTO(
+        @Schema(description = "Nombre de la categoría", example = "Programación")
         @NotBlank
         String name
 ) {

--- a/src/main/java/com/example/skilllinkbackend/features/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/challenge/controller/ChallengeController.java
@@ -4,6 +4,12 @@ import com.example.skilllinkbackend.features.challenge.dto.ChallengeRegisterDTO;
 import com.example.skilllinkbackend.features.challenge.dto.ChallengeResponseDTO;
 import com.example.skilllinkbackend.features.challenge.dto.ChallengeUpdateDTO;
 import com.example.skilllinkbackend.features.challenge.service.IChallengeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
@@ -20,6 +26,8 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/challenges")
+@SecurityRequirement(name = "bearer-key")
+@Tag(name = "Desafíos", description = "Operaciones relacionadas con desafíos creados por mentores")
 public class ChallengeController {
 
     private final IChallengeService challengeService;
@@ -28,6 +36,16 @@ public class ChallengeController {
         this.challengeService = challengeService;
     }
 
+    @Operation(
+            summary = "Crear un nuevo desafío",
+            description = "Permite a los mentores crear un nuevo desafío.",
+            security = @SecurityRequirement(name = "bearer-key"),
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Desafío creado exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "Acceso denegado", content = @Content)
+            }
+    )
     @PostMapping
     @Transactional
     @PreAuthorize("hasRole('MENTOR')")
@@ -40,6 +58,17 @@ public class ChallengeController {
         return ResponseEntity.created(url).body(challengeResponse);
     }
 
+    @Operation(
+            summary = "Listar todos los desafíos con paginación",
+            parameters = {
+                    @Parameter(name = "page", description = "Número de página (0-indexado)", example = "0"),
+                    @Parameter(name = "size", description = "Cantidad de elementos por página", example = "10"),
+                    @Parameter(name = "sort", description = "Campo para ordenar (ej: id,asc)", example = "id,asc")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Lista de desafíos obtenida exitosamente")
+            }
+    )
     @GetMapping
     public ResponseEntity<Map<String, Object>> getChallenges(@PageableDefault(size = 10, sort = "id") Pageable pagination) {
         Page<ChallengeResponseDTO> challengesPage = challengeService.findAll(pagination);
@@ -54,11 +83,26 @@ public class ChallengeController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "Obtener desafío por ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Desafío encontrado"),
+                    @ApiResponse(responseCode = "404", description = "Desafío no encontrado", content = @Content)
+            }
+    )
     @GetMapping("/{id}")
     public ChallengeResponseDTO getChallengeById(@PathVariable Long id) {
         return challengeService.findById(id);
     }
 
+    @Operation(
+            summary = "Actualizar desafío existente",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Desafío actualizado exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "Desafío no encontrado", content = @Content)
+            }
+    )
     @PutMapping("/{id}")
     @Transactional
     public ChallengeResponseDTO updateChallenge(
@@ -68,6 +112,13 @@ public class ChallengeController {
         return challengeService.updateChallenge(id, challengeDto);
     }
 
+    @Operation(
+            summary = "Eliminar desafío por ID",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Desafío eliminado exitosamente"),
+                    @ApiResponse(responseCode = "404", description = "Desafío no encontrado", content = @Content)
+            }
+    )
     @DeleteMapping("/{id}")
     @Transactional
     public ResponseEntity<Void> deleteChallenge(@PathVariable Long id) {

--- a/src/main/java/com/example/skilllinkbackend/features/challenge/dto/ChallengeRegisterDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/challenge/dto/ChallengeRegisterDTO.java
@@ -1,20 +1,33 @@
 package com.example.skilllinkbackend.features.challenge.dto;
 
 import com.example.skilllinkbackend.features.challenge.model.StatusChallenge;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "Datos necesarios para crear un desafío")
 public record ChallengeRegisterDTO(
+        @Schema(description = "Título del desafío", example = "Desafío de Java Básico")
         @NotBlank
         String title,
 
+        @Schema(description = "Descripción del desafío", example = "Aplicando los principios de Java")
         String description,
 
+        @Schema(description = "Resultados del desafío", example = "El 100% de los alumnos deben completar el desafío")
         String results,
 
+        @Schema(
+                description = "Estado del desafío. Valores posibles: ACTIVED, CLOSED",
+                example = "ACTIVED"
+        )
         @NotNull
         StatusChallenge status,
 
+        @Schema(
+                description = "ID del creador del desafío (mentor responsable)",
+                example = "42"
+        )
         @NotNull
         Long creatorId
 ) {

--- a/src/main/java/com/example/skilllinkbackend/features/challenge/dto/ChallengeUpdateDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/challenge/dto/ChallengeUpdateDTO.java
@@ -1,26 +1,40 @@
 package com.example.skilllinkbackend.features.challenge.dto;
 
 import com.example.skilllinkbackend.features.challenge.model.StatusChallenge;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
+@Schema(description = "Datos necesarios para editar un desafío")
 public record ChallengeUpdateDTO(
 
+        @Schema(description = "Id del desafío", example = "1")
         @NotNull
         @Positive(message = "El id debe ser un número positivo")
         Long id,
 
+        @Schema(description = "Título del desafío", example = "Programación en C++")
         @NotBlank
         String title,
 
+        @Schema(description = "Descripción del desafío", example = "Elaborar una calculadora")
         String description,
 
+        @Schema(description = "Resultados del desafío", example = "Lograr un calculadora funcional")
         String results,
 
+        @Schema(
+                description = "Estado del desafío. Valores posibles: ACTIVED, CLOSED",
+                example = "ACTIVED"
+        )
         @NotNull
         StatusChallenge status,
 
+        @Schema(
+                description = "ID del creador del desafío (mentor responsable)",
+                example = "42"
+        )
         @NotNull
         Long creatorId
 ) {

--- a/src/main/java/com/example/skilllinkbackend/features/challenge/model/StatusChallenge.java
+++ b/src/main/java/com/example/skilllinkbackend/features/challenge/model/StatusChallenge.java
@@ -1,5 +1,8 @@
 package com.example.skilllinkbackend.features.challenge.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Estados posibles para un desafío")
 public enum StatusChallenge {
     ACTIVED, CLOSED
 }

--- a/src/main/java/com/example/skilllinkbackend/features/evaluation/controller/EvaluationController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/evaluation/controller/EvaluationController.java
@@ -4,6 +4,12 @@ import com.example.skilllinkbackend.features.evaluation.dto.EvaluationRegisterDT
 import com.example.skilllinkbackend.features.evaluation.dto.EvaluationResponseDTO;
 import com.example.skilllinkbackend.features.evaluation.dto.EvaluationUpdateDTO;
 import com.example.skilllinkbackend.features.evaluation.service.IEvaluationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
@@ -19,6 +25,8 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/evaluations")
+@SecurityRequirement(name = "bearer-key")
+@Tag(name = "Evaluaciones", description = "Operaciones relacionadas con la evaluación de desafíos")
 public class EvaluationController {
 
     private final IEvaluationService evaluationService;
@@ -27,6 +35,14 @@ public class EvaluationController {
         this.evaluationService = evaluationService;
     }
 
+    @Operation(
+            summary = "Crear una nueva evaluación",
+            description = "Registra una evaluación hecha a un desafío por un mentor o evaluador.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Evaluación creada exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content)
+            }
+    )
     @PostMapping
     @Transactional
     public ResponseEntity<EvaluationResponseDTO> createEvaluation(
@@ -37,6 +53,17 @@ public class EvaluationController {
         return ResponseEntity.created(url).body(evaluationResponse);
     }
 
+    @Operation(
+            summary = "Listar todas las evaluaciones con paginación",
+            parameters = {
+                    @Parameter(name = "page", description = "Número de página (0-indexado)", example = "0"),
+                    @Parameter(name = "size", description = "Cantidad de elementos por página", example = "10"),
+                    @Parameter(name = "sort", description = "Campo para ordenar (ej: id,asc)", example = "id,asc")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Lista de evaluaciones obtenida exitosamente")
+            }
+    )
     @GetMapping
     public Map<String, Object> findAll(@PageableDefault(size = 10, sort = "id") Pageable pagination) {
         Page<EvaluationResponseDTO> evaluationsPage = evaluationService.findAll(pagination);
@@ -51,11 +78,26 @@ public class EvaluationController {
         return response;
     }
 
+    @Operation(
+            summary = "Obtener evaluación por ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Evaluación encontrada"),
+                    @ApiResponse(responseCode = "404", description = "Evaluación no encontrada", content = @Content)
+            }
+    )
     @GetMapping("/{id}")
     public EvaluationResponseDTO findById(@PathVariable Long id) {
         return evaluationService.findById(id);
     }
 
+    @Operation(
+            summary = "Actualizar evaluación existente",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Evaluación actualizada exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "Evaluación no encontrada", content = @Content)
+            }
+    )
     @PutMapping("/{id}")
     @Transactional
     public EvaluationResponseDTO updateEvaluation(
@@ -65,6 +107,13 @@ public class EvaluationController {
         return evaluationService.updateEvaluation(id, evaluationDto);
     }
 
+    @Operation(
+            summary = "Eliminar evaluación por ID",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Evaluación eliminada exitosamente"),
+                    @ApiResponse(responseCode = "404", description = "Evaluación no encontrada", content = @Content)
+            }
+    )
     @DeleteMapping("/{id}")
     @Transactional
     public ResponseEntity<Void> deleteEvaluation(@PathVariable Long id) {

--- a/src/main/java/com/example/skilllinkbackend/features/evaluation/dto/EvaluationRegisterDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/evaluation/dto/EvaluationRegisterDTO.java
@@ -1,24 +1,31 @@
 package com.example.skilllinkbackend.features.evaluation.dto;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "Datos necesarios para crear una evaluación")
 public record EvaluationRegisterDTO(
+        @Schema(description = "Puntaje de la evaluación", example = "4")
         @Min(1)
         @Max(5)
         @NotNull(message = "El puntaje es necesario")
         Double score,
 
+        @Schema(description = "Comentarios de la evaluación", example = "Buen trabajo, sigue así!")
         String feedback,
 
+        @Schema(description = "Id del evaluador", example = "1")
         @NotNull(message = "El id del evaluador es necesario")
         Long evaluatorId,
 
+        @Schema(description = "Id del evaluado", example = "2")
         @NotNull(message = "El id del evaluado es necesario")
         Long evaluatedId,
 
+        @Schema(description = "Id del desafío", example = "4")
         @NotNull(message = "El id del desafio es necesario")
         Long challengeId
 ) {

--- a/src/main/java/com/example/skilllinkbackend/features/evaluation/dto/EvaluationUpdateDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/evaluation/dto/EvaluationUpdateDTO.java
@@ -1,5 +1,6 @@
 package com.example.skilllinkbackend.features.evaluation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -7,26 +8,34 @@ import jakarta.validation.constraints.Positive;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "Datos necesarios para editar una evaluación")
 public record EvaluationUpdateDTO(
 
+        @Schema(description = "Id de la evaluación", example = "4")
         @NotNull
         @Positive(message = "El id debe ser un número positivo")
         Long id,
 
+        @Schema(description = "Puntaje de la evaluación", example = "4")
         @Min(1)
         @Max(5)
         Double score,
 
-
+        @Schema(description = "Comentarios de la evaluación", example = "Buen trabajo, sigue así!")
         String feedback,
+
+        @Schema(description = "Fecha de creación", example = "2025-07-01T21:48:57")
         LocalDateTime createdAt,
 
+        @Schema(description = "Id del evaluador", example = "1")
         @NotNull(message = "El id del evaluador es necesario")
         Long evaluatorId,
 
+        @Schema(description = "Id del evaluado", example = "2")
         @NotNull(message = "El id del evaluado es necesario")
         Long evaluatedId,
 
+        @Schema(description = "Id del desafío", example = "4")
         @NotNull(message = "El id del desafío es necesario")
         Long challengeId
 ) {

--- a/src/main/java/com/example/skilllinkbackend/features/project/controller/ProjectController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/project/controller/ProjectController.java
@@ -4,6 +4,12 @@ import com.example.skilllinkbackend.features.project.dto.ProjectRegisterDTO;
 import com.example.skilllinkbackend.features.project.dto.ProjectResponseDTO;
 import com.example.skilllinkbackend.features.project.dto.ProjectUpdateDTO;
 import com.example.skilllinkbackend.features.project.service.IProjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
@@ -19,6 +25,8 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/projects")
+@SecurityRequirement(name = "bearer-key")
+@Tag(name = "Proyectos", description = "Operaciones CRUD relacionadas con proyectos creados por los usuarios")
 public class ProjectController {
     private final IProjectService projectService;
 
@@ -26,6 +34,14 @@ public class ProjectController {
         this.projectService = projectService;
     }
 
+    @Operation(
+            summary = "Crear un nuevo proyecto",
+            description = "Crea un nuevo proyecto a partir de los datos enviados",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Proyecto creado exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content)
+            }
+    )
     @PostMapping
     @Transactional
     public ResponseEntity<ProjectResponseDTO> createProject(
@@ -36,6 +52,17 @@ public class ProjectController {
         return ResponseEntity.created(url).body(projectResponse);
     }
 
+    @Operation(
+            summary = "Listar todos los proyectos con paginación",
+            parameters = {
+                    @Parameter(name = "page", description = "Número de página (0-indexado)", example = "0"),
+                    @Parameter(name = "size", description = "Cantidad de elementos por página", example = "10"),
+                    @Parameter(name = "sort", description = "Campo de ordenamiento (ej: id,asc)", example = "id,asc")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Lista de proyectos obtenida exitosamente")
+            }
+    )
     @GetMapping
     public Map<String, Object> getProjects(@PageableDefault(size = 10, sort = "id") Pageable pagination) {
         Page<ProjectResponseDTO> projectPage = projectService.getProjects(pagination);
@@ -50,11 +77,26 @@ public class ProjectController {
         return response;
     }
 
+    @Operation(
+            summary = "Obtener un proyecto por ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Proyecto encontrado"),
+                    @ApiResponse(responseCode = "404", description = "Proyecto no encontrado", content = @Content)
+            }
+    )
     @GetMapping("/{id}")
     public ProjectResponseDTO findById(@PathVariable Long id) {
         return projectService.findById(id);
     }
 
+    @Operation(
+            summary = "Actualizar un proyecto existente",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Proyecto actualizado exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "Proyecto no encontrado", content = @Content)
+            }
+    )
     @PutMapping("/{id}")
     @Transactional
     public ProjectResponseDTO updateProject(
@@ -63,6 +105,13 @@ public class ProjectController {
         return projectService.updateProject(id, projectUpdateDTO);
     }
 
+    @Operation(
+            summary = "Eliminar un proyecto por ID",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Proyecto eliminado exitosamente"),
+                    @ApiResponse(responseCode = "404", description = "Proyecto no encontrado", content = @Content)
+            }
+    )
     @DeleteMapping("/{id}")
     @Transactional
     public ResponseEntity<Void> deleteProject(@PathVariable Long id) {

--- a/src/main/java/com/example/skilllinkbackend/features/project/dto/ProjectRegisterDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/project/dto/ProjectRegisterDTO.java
@@ -1,33 +1,50 @@
 package com.example.skilllinkbackend.features.project.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "Datos necesarios para crear un proyecto")
 public record ProjectRegisterDTO(
 
+        @Schema(description = "Id del creador", example = "4")
         @NotNull
         Long creatorId,
 
+        @Schema(description = "Nombre del proyecto", example = "Calculadora Stylgar")
         @NotBlank
         String name,
 
+        @Schema(description = "Descripción del proyecto", example = "Calculadora funcional con las operaciones básicas")
         @NotBlank
         String description,
 
+        @Schema(description = "Fecha de inicio", example = "2025-07-01T21:48:57")
         @NotNull
         LocalDateTime startDate,
 
+        @Schema(description = "Fecha de finalización", example = "2025-08-01T21:48:57")
         @NotNull
         LocalDateTime endDate,
 
+        @Schema(description = "Visibilidad del proyecto. Posibles valores: publico, privado", example = "publico")
         @NotBlank
         String visibility,
 
         // correos de los miembros
+        @Schema(
+                description = "Lista de correos de los estudiantes miembros del proyecto",
+                example = "[\"alumno1@example.com\", \"alumno2@example.com\"]"
+        )
         List<String> members,
+
+        @Schema(
+                description = "Lista de IDs de categorías asociadas al proyecto",
+                example = "[1, 3, 5]"
+        )
         List<Long> categoriesId
 ) {
 }

--- a/src/main/java/com/example/skilllinkbackend/features/project/dto/ProjectUpdateDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/project/dto/ProjectUpdateDTO.java
@@ -1,36 +1,54 @@
 package com.example.skilllinkbackend.features.project.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "Datos necesarios para crear un proyecto")
 public record ProjectUpdateDTO(
 
+        @Schema(description = "Id del proyecto", example = "1")
         @NotNull
         Long id,
 
+        @Schema(description = "Id del creador", example = "4")
         @NotNull
         Long creatorId,
 
+        @Schema(description = "Nombre del proyecto", example = "Calculadora Stylgar")
         @NotBlank
         String name,
 
+        @Schema(description = "Descripción del proyecto", example = "Calculadora funcional con las operaciones básicas")
         @NotBlank
         String description,
 
+        @Schema(description = "Fecha de inicio", example = "2025-07-01T21:48:57")
         @NotNull
         LocalDateTime startDate,
 
+        @Schema(description = "Fecha final", example = "2025-08-01T21:48:57")
         @NotNull
         LocalDateTime endDate,
 
+        @Schema(description = "Visibilidad del proyecto. Posibles valores: publico, privado", example = "publico")
         @NotBlank
         String visibility,
 
         // correos de los miembros
+        @Schema(
+                description = "Lista de correos de los estudiantes miembros del proyecto",
+                example = "[\"alumno1@example.com\", \"alumno2@example.com\"]"
+        )
         List<String> members,
+
+        @Schema(
+                description = "Lista de IDs de categorías asociadas al proyecto",
+                example = "[1, 3, 5]"
+        )
         List<Long> categoriesId
 ) {
 }

--- a/src/main/java/com/example/skilllinkbackend/features/usuario/controller/UserController.java
+++ b/src/main/java/com/example/skilllinkbackend/features/usuario/controller/UserController.java
@@ -1,11 +1,17 @@
 package com.example.skilllinkbackend.features.usuario.controller;
 
-import com.example.skilllinkbackend.config.responses.ApiResponse;
+//import com.example.skilllinkbackend.config.responses.ApiResponse;
 import com.example.skilllinkbackend.config.responses.DataResponse;
 import com.example.skilllinkbackend.features.usuario.dto.RegisteredUserResponseDTO;
 import com.example.skilllinkbackend.features.usuario.dto.UserRegisterRequestDTO;
 import com.example.skilllinkbackend.features.usuario.dto.UserResponseDTO;
 import com.example.skilllinkbackend.features.usuario.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +26,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/users")
+@Tag(name = "Usuarios", description = "Operaciones relacionadas con los usuarios del sistema")
 public class UserController {
 
     private final UserService userService;
@@ -28,6 +35,21 @@ public class UserController {
         this.userService = userService;
     }
 
+    @Operation(
+            summary = "Obtener lista paginada de usuarios",
+            description = "Solo accesible por usuarios con rol ADMIN",
+            security = @SecurityRequirement(name = "bearer-key"),
+            parameters = {
+                    @Parameter(name = "page", description = "Número de página (0-indexado)", example = "0"),
+                    @Parameter(name = "size", description = "Cantidad de elementos por página", example = "10"),
+                    @Parameter(name = "sort", description = "Campo de ordenamiento, ej: userId,asc", example = "userId,asc")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Lista de usuarios obtenida correctamente"),
+                    @ApiResponse(responseCode = "403", description = "Acceso denegado (no tiene el rol ADMIN)", content = @Content)
+            }
+    )
+    @SecurityRequirement(name = "bearer-key")
     @GetMapping
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Map<String, Object>> getUsers(@PageableDefault(size = 10, sort = "userId") Pageable pagination) {
@@ -43,6 +65,14 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "Registrar un nuevo usuario",
+            description = "Registro público de un nuevo usuario en la plataforma",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Usuario registrado exitosamente"),
+                    @ApiResponse(responseCode = "400", description = "Datos inválidos o error en validación", content = @Content)
+            }
+    )
     @PostMapping("register")
     public ResponseEntity<DataResponse<RegisteredUserResponseDTO>> createUser(
             @RequestBody @Valid UserRegisterRequestDTO userDto) {

--- a/src/main/java/com/example/skilllinkbackend/features/usuario/dto/UserRegisterRequestDTO.java
+++ b/src/main/java/com/example/skilllinkbackend/features/usuario/dto/UserRegisterRequestDTO.java
@@ -1,37 +1,46 @@
 package com.example.skilllinkbackend.features.usuario.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "Datos necesarios para crear un usuario")
 public record UserRegisterRequestDTO(
+        @Schema(description = "Nombre del usuario", example = "Alexey")
         @NotBlank
         @Size(min = 2, max = 30)
         String firstName,
 
+        @Schema(description = "Apellido", example = "Kovack")
         @NotBlank
         @Size(min = 2, max = 50)
         String lastName,
 
+        @Schema(description = "Objetivos del usuario", example = "Aprender java y spring boot")
         @NotBlank
         @Size(min = 2, max = 500)
         String goals,
 
+        @Schema(description = "Correo del usuario", example = "alexey@gmail.com")
         @NotBlank
         @Email
         String email,
 
+        @Schema(description = "Contraseña del usuario", example = "12345678A")
         @NotNull
         @Size(min = 8, max = 15, message = "La contraseña debe tener entre 8 y 15 caracteres")
         String password,
 
+        @Schema(description = "Biografía del usuario", example = "Estudiante de la carrera de Ingeniería Industrial")
         @NotBlank
         @Size(min = 2, max = 500)
         String biography,
 
+        @Schema(description = "URL de la foto", example = "https://cdn-icons-png.flaticon.com/128/18851/18851112.png")
         @NotBlank
-        @Size(min = 2, max = 150)
+        @Size(min = 2, max = 350)
         String photo
 ) {
 }


### PR DESCRIPTION
## ✨ Configuración de Swagger (SpringDoc) para documentación de API

### 📌 Descripción

Este Pull Request incorpora y configura **Swagger (SpringDoc)** para documentar de forma automática los endpoints del proyecto `Skilllink-Backend`. Se realizaron ajustes tanto en la configuración general del proyecto como en los controladores y DTOs involucrados para mejorar la generación automática de la documentación.

### 🛠️ Cambios realizados

- **`pom.xml`**  
  - Se agregaron las dependencias necesarias para SpringDoc OpenAPI.

- **`SpringDocConfiguration.java`**  
  - Clase creada o modificada para personalizar la documentación de la API (título, descripción, versión, etc.).

- **`SecurityConfigurations.java`**  
  - Ajustes para permitir el acceso público a la interfaz Swagger.

- **Controladores modificados**  
  Se añadieron anotaciones de documentación (`@Operation`, `@ApiResponse`, `@Tag`, etc.):
  - `AuthenticationController.java`
  - `CategoryController.java`
  - `ChallengeController.java`
  - `EvaluationController.java`
  - `ProjectController.java`
  - `UserController.java`

- **DTOs modificados**  
  Se documentaron campos con anotaciones como `@Schema`, `@NotNull`, `@Size`, entre otras:
  - `UserAuthenticationDataDTO.java`
  - `CategoryRegisterDTO.java`
  - `ChallengeRegisterDTO.java`
  - `ChallengeUpdateDTO.java`
  - `EvaluationRegisterDTO.java`
  - `EvaluationUpdateDTO.java`
  - `ProjectRegisterDTO.java`
  - `ProjectUpdateDTO.java`
  - `UserRegisterRequestDTO.java`

- **Modelo modificado**  
  - `StatusChallenge.java`: Documentado como enumeración para mostrar posibles valores en Swagger.

### ✅ Objetivo

Contar con una interfaz de documentación accesible desde `/swagger-ui.html` o `/swagger-ui/index.html` que permita:

- Visualizar y probar endpoints de forma interactiva.
- Comprender los contratos de entrada/salida de la API.
- Facilitar la colaboración con otros desarrolladores y testers.

